### PR TITLE
Disable image optimization for GeneralImage and set priority for splash image

### DIFF
--- a/src/components/ChampionDetail/index.tsx
+++ b/src/components/ChampionDetail/index.tsx
@@ -141,7 +141,7 @@ export function ChampionDetailContainer({
             src={splashUrl}
             alt={`${champion.name} splash art`}
             className="object-top object-cover transform scale-105 transition-transform duration-1000 hover:scale-110"
-            priority
+            priority={true}
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 1200px"
             fallbackSrc={fallbackUrl}
           />

--- a/src/components/ui/GeneralImage.tsx
+++ b/src/components/ui/GeneralImage.tsx
@@ -34,6 +34,8 @@ export function GeneralImage({
         const target = e.currentTarget as HTMLImageElement;
         target.src = fallbackSrc;
       }}
+      //Disable Next.js image optimization for this component
+      unoptimized={true}
     />
   );
 }


### PR DESCRIPTION
Disable Next.js image optimization for the GeneralImage component and set the priority attribute to true for the splash image in the ChampionDetailContainer.